### PR TITLE
:lock: Force Single Logout

### DIFF
--- a/app/public/actions/login.php
+++ b/app/public/actions/login.php
@@ -5,6 +5,7 @@
     // Perform the OIDC authentication
     try {
       $oidc->authenticate();
+      $_SESSION['access_token'] = $oidc->requestClientCredentialsToken()->access_token;
       $oidc_user = array(
         'sub' => $oidc->requestUserInfo('sub'),
         'username' => $oidc->requestUserInfo('preferred_username'),

--- a/app/public/actions/logout.php
+++ b/app/public/actions/logout.php
@@ -2,7 +2,7 @@
     $PAGE_NAME = "Logging out...";
     require_once __DIR__ . "/../../includes/prereqs.php";
 
+    $access_token = $_SESSION['access_token'];
     session_destroy();
-
-    header('Location: /');
+    $oidc->signOut($access_token, $_ENV['APP_URL']);
 ?>


### PR DESCRIPTION
This PR will ensure that when a user logs out, the IDP is notified so it can end the user's SSO session.

Signed-off-by: Luke Tainton <luke@tainton.uk>