### PR TITLE
🐛 Move opening and closing 'main' tags

### DIFF
--- a/app/includes/footer.php
+++ b/app/includes/footer.php
@@ -1,3 +1,4 @@
+</main>
 <footer class="footer mt-auto py-3">
   <div class="text-center text-muted">
     <?php

--- a/app/includes/header.php
+++ b/app/includes/header.php
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#563d7c">
     <link rel="icon" type="image/png" href="/favicon.png">
-    <title><?php echo( $PAGE_TITLE ); ?></title>
+    <title><?php echo($PAGE_TITLE); ?></title>
 
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="/css/bootstrap.min.css">
@@ -34,10 +34,14 @@
                 <a class="nav-link" href="/">Home</a>
                 </li>
                 <li class="nav-item">
-                <a class="nav-link <?php if (!is_signed_in()) {echo(' disabled');} ?>" href="/new">New request</a>
+                <a class="nav-link <?php if (!is_signed_in()) {
+    echo(' disabled');
+} ?>" href="/new">New request</a>
                 </li>
                 <li class="nav-item">
-                <a class="nav-link <?php if (!is_signed_in()) {echo(' disabled');} ?>" href="/existing">Existing requests</a>
+                <a class="nav-link <?php if (!is_signed_in()) {
+    echo(' disabled');
+} ?>" href="/existing">Existing requests</a>
                 </li>
             </ul>
         <div class="mt-2 mt-md-0">

--- a/app/includes/header.php
+++ b/app/includes/header.php
@@ -19,6 +19,8 @@
   </head>
 
   <body class="d-flex flex-column h-100">
+    <!-- Begin page content -->
+    <main role="main" class="flex-shrink-0">
     <header>
     <!-- Fixed navbar -->
     <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">

--- a/app/public/index.php
+++ b/app/public/index.php
@@ -3,8 +3,8 @@
     require_once __DIR__ . "/../includes/header.php";
 
     if (is_signed_in()) {
-      $requests = get_my_open_requests($db);
-      $subscriptions = get_open_subscribed_requests($db);
+        $requests = get_my_open_requests($db);
+        $subscriptions = get_open_subscribed_requests($db);
     }
 
 ?>
@@ -12,8 +12,8 @@
 
   <section>
     <?php
-      if(isset($alert)) {
-        echo("
+      if (isset($alert)) {
+          echo("
         <div class='container'>
           <div class='alert alert-" . $alert[0] . " alert-dismissible fade show' role='alert'>
             " . $alert[1] . "
@@ -23,7 +23,7 @@
           </div>
         </div>
       ");
-      unset($alert);
+          unset($alert);
       }
     ?>
   </section>
@@ -33,7 +33,11 @@
       <h1>Welcome to <?php echo($_ENV['APP_NAME']); ?></h1>
       <p class="lead text-muted">
         <?php
-          if ($_ENV['APP_NAME'] == "FHeD") {echo("The Free HelpDesk");} else {echo($_ENV['APP_NAME']);};
+          if ($_ENV['APP_NAME'] == "FHeD") {
+              echo("The Free HelpDesk");
+          } else {
+              echo($_ENV['APP_NAME']);
+          };
         ?>
         is the one-stop shop for all of your IT-related needs. Let us know how we can help you by opening a request.
       </p>
@@ -59,10 +63,10 @@
             <ul class="list-group list-group-flush">
               <?php
                 if (count($requests) == 0) {
-                  echo("<center><b>No open tickets</b></center>");
+                    echo("<center><b>No open tickets</b></center>");
                 } else {
-                  foreach($requests as $tkt) {
-              ?>
+                    foreach ($requests as $tkt) {
+                        ?>
               <li class="list-group-item">
                 <div class="container">
                   <div class="row">
@@ -76,7 +80,9 @@
                   </div>
                 </div>
               </li>
-              <?php } } ?>
+              <?php
+                    }
+                } ?>
             </ul>
           </div>
         </div>
@@ -89,9 +95,9 @@
             <ul class="list-group list-group-flush">
               <?php
                 if (count($subscriptions) == 0) {
-                  echo("<center><b>No subscribed tickets</b></center>");
+                    echo("<center><b>No subscribed tickets</b></center>");
                 } else {
-                  foreach($subscriptions as $sub) { ?>
+                    foreach ($subscriptions as $sub) { ?>
               <li class="list-group-item">
                 <div class="container">
                   <div class="row">
@@ -105,7 +111,8 @@
                   </div>
                 </div>
               </li>
-              <?php } } ?>
+              <?php }
+                } ?>
             </ul>
           </div>
         </section>

--- a/app/public/index.php
+++ b/app/public/index.php
@@ -10,10 +10,6 @@
 ?>
 
 
-
-<!-- Begin page content -->
-<main role="main" class="flex-shrink-0">
-
   <section>
     <?php
       if(isset($alert)) {
@@ -117,8 +113,6 @@
       </div>
     </div>
   <?php } ?>
-
-</main>
 
 <?php
     require_once __DIR__ . "/../includes/footer.php";


### PR DESCRIPTION
## Description
The `main` opening and closing tags have been moved, so that the navbar is forced to appear above the alert, not over the top of it.

Fixes #117 
Signed-off-by: Luke Tainton <luke@tainton.uk>

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I read & comply with the [contributing guidelines](https://github.com/luketainton/FHeD/blob/main/.github/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes the documentation (README.md).